### PR TITLE
Add support for Dart SASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Double Dash is a SCSS library helping to declare [custom media queries](docs/cus
 
 **Dart SASS support starts at version 1.0.**
 
-- `npm install double-dash.scss` pulls the package into your project;
+- `npm install double-dash.scss@dart-sass` pulls the package into your project;
 - `@use 'double-dash.scss' as mq;` in all projects where you need one of its mixins or variables. `mq` is the recommended [namespace](https://sass-lang.com/documentation/at-rules/use#choosing-a-namespace) for `double-dash.scss`.
 
 ### Projects using `node-sass`
 
 **Projects using `node-sass` must stick to version `0.x`**
 
-- `npm install double-dash.scss@0` pulls the package into your project;
+- `npm install double-dash.scss@0` pulls the package into your project (for now, the `@0` part isn’t needed);
 - `@import 'double-dash.scss';` near the beginning of the main SCSS file enables Double Dash features.
 
 ### Browser support

--- a/README.md
+++ b/README.md
@@ -6,29 +6,59 @@ Double Dash is a SCSS library helping to declare [custom media queries](docs/cus
 - predefined custom media queries, covering the whole specs;
 - mixins that generate *ranged* media queries (`min-width`, `max-width`…).
 
+⚠️ **To use `double-dash.scss` in a `node-sass` project, see [v0.8 documentation](https://github.com/meduzen/--media.scss/tree/v0.8.0#contents)**. If you’re not sure about your environment, start with the [installation section](#installation).
+
 ## Contents
 
 - [Installation](#installation)
 - [Predefined custom media queries](#predefined-custom-media-queries)
   - [Color scheme (`prefers-color-scheme`)](#colors-scheme-prefers-color-scheme)
+  - [Connectivity (`prefers-reduced-data`)](#connectivity-prefers-reduced-data)
   - [Contrast (`prefers-contrast`)](#contrast-prefers-contrast)
   - [Display (`display-mode`)](#display-display-mode)
   - [Motion (`prefers-reduced-motion`)](#motion-prefers-reduced-motion)
-  - [Ratios (`aspect-ratio`)](#ratios-aspect-ratio)
-  - [Connectivity (`prefers-reduced-data`)](#connectivity-prefers-reduced-data)
+  - [Ratio (`aspect-ratio`)](#ratio-aspect-ratio)
   - [Others](#others)
 - [Mixins for ranged media queries](#mixins-for-ranged-media-queries)
     - [Introduction](#introduction)
     - [Available mixins](#available-mixins)
+      - [Width and height](#width-and-height)
+      - [Resolution](#resolution)
+      - [Ratio](#ratio)
 - [Partial import](#partial-import)
 - [Debug](#debug)
 
 ## Installation
 
-- `npm install double-dash.scss` pulls the package into your project.
-- `@import '~double-dash.scss';` near the beginning of the main SCSS file enables Double Dash features.
+💡 `double-dash.scss` supports both the old and the new (2020) SASS specification, but the usage of the library varies per spec.
 
-💡 Awaiting for browsers to embrace Custom Media Queries, some CSS post-processing is needed. [Post CSS Preset Env](https://preset-env.cssdb.org/) perfectly fills this gap.
+<details>
+
+<summary>If you’re not sure which one your project uses, this might help.</summary>
+
+- If the project uses `node-sass` **or** if you import SCSS files using `@import`, there’s a high chance you use **the old spec**.
+- If the project uses Dart SASS (`sass`) **and** if you import SCSS files using `@use` or `@forward`, you are using **the new spec**.
+- In the new spec, `@import` is deprecated and variables are not global. This is why `double.dash.scss` usage isn’t the same changes depending on the spec.
+
+</details>
+
+### Projects using Dart SASS
+
+**Dart SASS support starts at version 1.0.**
+
+- `npm install double-dash.scss` pulls the package into your project;
+- `@use 'double-dash.scss' as mq;` in all projects where you need one of its mixins or variables. `mq` is the recommended [namespace](https://sass-lang.com/documentation/at-rules/use#choosing-a-namespace) for `double-dash.scss`.
+
+### Projects using `node-sass`
+
+**Projects using `node-sass` must stick to version `0.x`**
+
+- `npm install double-dash.scss@0` pulls the package into your project;
+- `@import 'double-dash.scss';` near the beginning of the main SCSS file enables Double Dash features.
+
+### Browser support
+
+💡 Awaiting for browsers to embrace Custom Media Queries, [PostCSS Preset Env](https://preset-env.cssdb.org) is perfect to fill the gap. If you need an example of a small project using both `double-dash.scss` and PostCSS, you can have a look at [Can We](https://github.com/meduzen/canwe) repository.
 
 ## Predefined custom media queries
 
@@ -41,6 +71,19 @@ Double Dash provides a set of custom media queries usable in `@media` rules out 
 **`--light`**: the user prefers a light UI or has no colors preference.
 Aliases: `--any-theme`, `--any-color-scheme`, `--no-theme-preference`, `--no-color-scheme-preference`.
 
+Example:
+```scss
+html {
+  background: white;
+  color: black;
+
+  @media (--dark) {
+    background: black;
+    color: white;
+  }
+}
+```
+
 ### Contrast ([prefers-contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast))
 
 **`--more-contrast`**: the user prefers a UI with a higher level of contrast.
@@ -51,6 +94,25 @@ Alias: `--low-contrast`.
 
 **`--no-contrast-preference`**: the user has no contrast preference.
 Aliases: `--any-contrast`, `--normal-contrast`.
+
+### Connectivity ([prefers-reduced-data](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-data))
+
+**`--reduced-data`**: the user prefers to save data.
+Alias: `--data-shortage`.
+
+**`--no-data-preference`**: the user doesn’t prefer to save data.
+Alias: `--data`.
+
+Example:
+```scss
+.hero {
+  background-image: url('wedding-pic-2048-1024.webp');
+
+  @media (--reduced-data) {
+    background-image: none;
+  }
+}
+```
 
 ### Display ([display-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode))
 
@@ -84,7 +146,7 @@ Example:
 }
 ```
 
-### Ratios ([aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio))
+### Ratio ([aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio))
 
 **`--landscape`**: the viewport width is greater than its height.
 Alias: `--horizontal`.
@@ -93,25 +155,6 @@ Alias: `--horizontal`.
 
 **`--portrait`**: the viewport width is smaller than its height.
 Alias: `--vertical`.
-
-### Connectivity ([prefers-reduced-data](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-data))
-
-**`--reduced-data`**: the user prefers to save data.
-Alias: `--data-shortage`.
-
-**`--no-data-preference`**: the user doesn’t prefer to save data.
-Alias: `--data`.
-
-Example:
-```scss
-.hero {
-  background-image: url('wedding-pic-2048-1024.webp');
-
-  @media (--reduced-data) {
-    background-image: none;
-  }
-}
-```
 
 ### Others
 
@@ -124,6 +167,8 @@ Example:
 Mixins for ranged media queries generate a lot of custom media queries based on breakpoints lists.
 
 ```scss
+@use 'double-dash.scss' as mq;
+
 // Gather component breakpoints in a SCSS list.
 $nav-breakpoints: (
   'nav-collapsed': 45em,
@@ -131,10 +176,10 @@ $nav-breakpoints: (
 );
 
 // One mixin to generate them all.
-@include --w($nav-breakpoints);
+@include mq.w($nav-breakpoints);
 ```
 
-This unique `--w` mixin call generates all these width-based custom media queries:
+This unique `w` mixin call generates the following width-based custom media queries:
 ```scss
 // min-width
 --nav-collapsed // (min-width: 45em)
@@ -151,7 +196,7 @@ This unique `--w` mixin call generates all these width-based custom media querie
 They are now all usable in `@media`:
 
 ```css
-@media(--nav-expanded) {
+@media (--nav-expanded) {
   .nav-toggle-btn { display: none; }
 }
 ```
@@ -161,17 +206,19 @@ They are now all usable in `@media`:
 #### Width and height
 
 ```scss
-@include --w-from(name, width);
-@include --w-to(name, width);
-@include --w-is(name, width);
-@include --w-from-to(name, smallerWidth, otherName, greaterWidth);
-@include --w(widthsList);
+@use 'double-dash.scss' as mq;
 
-@include --h-from(name, height);
-@include --h-to(name, height);
-@include --h-is(name, height);
-@include --h-from-to(name, smallerHeight, otherName, greaterHeight);
-@include --h(heightsList);
+@include mq.w-from(name, width);
+@include mq.w-to(name, width);
+@include mq.w-is(name, width);
+@include mq.w-from-to(name, smallerWidth, otherName, greaterWidth);
+@include mq.w(widthsList);
+
+@include mq.h-from(name, height);
+@include mq.h-to(name, height);
+@include mq.h-is(name, height);
+@include mq.h-from-to(name, smallerHeight, otherName, greaterHeight);
+@include mq.h(heightsList);
 ```
 
 [Width and height mixins documentation](/docs/ranged-sizes-mixins.md).
@@ -179,10 +226,12 @@ They are now all usable in `@media`:
 #### Resolution
 
 ```scss
-@include --resolution-from(name, pxDensityFactor);
-@include --resolution-to(name, pxDensityFactor);
-@include --resolution-is(name, pxDensityFactor);
-@include --resolution(resolutionsList);
+@use 'double-dash.scss' as mq;
+
+@include mq.resolution-from(name, pxDensityFactor);
+@include mq.resolution-to(name, pxDensityFactor);
+@include mq.resolution-is(name, pxDensityFactor);
+@include mq.resolution(resolutionsList);
 ```
 
 [Resolution mixins documentation](/docs/ranged-resolutions-mixins.md).
@@ -200,32 +249,25 @@ The purpose of partial import is to avoid naming conflicts with existing custom 
 This examples only pulls the `prefers-reduced-motion` custom media queries:
 
 ```scss
-`@import '~double-dash.scss/src/variables/motion';`
+@use 'double-dash.scss/src/variables/motion';
 ```
 
 Available files: `color`, `js`, `light`, `motion`, `pointer`, `ratio`, `refresh`, `resolution`, `ui`.
 
 ### Import mixins for ranged media queries
 
-First, import the generic `--media` mixins (the other mixins use it):
+Example for the resolution mixins:
 
 ```scss
-@import '~double-dash.scss/src/mixins/base';
-```
-
-Then, pulls the mixins for viewport sizes custom media queries:
-
-```scss
-@import '~double-dash.scss/src/mixins/sizes';
+@use 'double-dash.scss/src/mixins/sizes' as mq;
 ```
 
 Available files: `ratio`, `resolution`, `sizes`.
 
 ## Debug
 
-You can output each custom media query generated with Double Dash in your CLI by setting the `$dash-dash-debug` variable before importing Double Dash.
+You can output each custom media query generated with Double Dash in your CLI by setting the `$debug` variable when importing Double Dash.
 
 ```scss
-$dash-dash-debug: true;
-@import '~double-dash.scss';
+@use 'double-dash.scss' with ($debug: true);
 ```

--- a/docs/custom-media-queries.md
+++ b/docs/custom-media-queries.md
@@ -72,16 +72,16 @@ Don’t need SCSS | ✅ | ❌ | ✅ | ❌
 Don’t need PostCSS now | ✅ | ✅ | ❌ | ❌
 Won’t need PostCSS in the future | ✅ | ✅ | ✅ | ✅
 Concise declaration | no declaration | ❌ (mixins and/or variables) | ❌ | ✅ partly invisible
-Concise use | ❌ | ☑️ | ✅ | ✅ 
-Combining queries | easy but unreadable | nesting (extra indentations) or advanced mixins | easy and readable | easy and readable
+Concise use | ❌ | ☑️ (almost) | ✅ | ✅ 
+Combining queries | easy but low readability | nesting or advanced mixins | easy and readable | easy and readable
 Explicit naming | ❌ | ☑️ (a lot of efforts for queries combinations) | ✅ | ✅
-No naming conflict with SCSS variables | ✅ | ❌ (if breakpoint variables) | ✅ | ✅
+No naming conflict with SCSS variables | ✅ | ❌ (when using breakpoint variables) | ✅ | ✅
 Lighter CSS bundle in the future | ❌ | ❌ | ✅ | ✅
 
 ## What’s next?
 
 - [Media query ranges](/docs/media-queries-ranges.md), another cool thing from the CSS Media Queries specs level 4 and 5.
-- Supercharge your Custom media queries workflow with [Double Dash](/)!!
+- Supercharge your custom media queries workflow with [Double Dash](/)!!
 
 ## Example: dark mode
 
@@ -124,13 +124,19 @@ For this example, we style a navigation menu:
 *Words are not the best way to shape a clear understanding of what we try to achieve. But let’s try.*
 
 The navigation menu:
-- is sticky on small viewports (but not on too small height);
+- is sticky on small viewports (except when the height is too small);
 - has a transparent background when sticky;
 - has a background image on greater viewport.
 
 The served background image varies depending on:
 - viewport pixels density;
 - color scheme.
+
+In other words, this advanced scenario relies on 4 factors:
+- the viewport size;
+- the screen pixel density;
+- the operating system color schemes;
+- the stickiness state of the navigation menu.
 
 ### Plain media query
 

--- a/docs/ranged-resolutions-mixins.md
+++ b/docs/ranged-resolutions-mixins.md
@@ -12,60 +12,88 @@ The reference unit in Double Dash is the `dppx`. Currently, `dpcm` are unsupport
 | 1.3 | 124.8 | Google Nexus 7 2012
 | 1.5 | 144 | Samsung Galaxy Watch 2018
 | 2 | 192 | most Macbook Pro and iPad models, iPhone 6
-| 2.46875 | 237 | Nintendo Switch
+| 2.46875 | 236.87 | Nintendo Switch
 | 3 | 288 | iPhone XS Max
 
+## Mixins import
 
-## Mixins syntaxes
+Use one of these two to import the mixins in your file:
 
 ```scss
-@include --resolution-from(name, pxDensityFactor);
-@include --resolution-to(name, pxDensityFactor);
-@include --resolution-is(name, pxDensityFactor);
-@include --resolution(resolutionsList);
+// import all double-dash.scss
+@use 'double-dash.scss' as mq;
+
+// only import resolution mixins
+@use 'double-dash.scss/src/mixins/resolution' as mq;
 ```
 
-## `min-`, `max-` and exact resolution examples
+## Syntax
 
 ```scss
-@include --resolution-from(hidpi, 1.3);
-@include --resolution-to(ldpi, 1.3);
-@include --resolution-is(dppx-switch, 2.46875);
+@include mq.resolution-from(name, pxDensityFactor);
+@include mq.resolution-to(name, pxDensityFactor);
+@include mq.resolution-is(name, pxDensityFactor);
+@include mq.resolution(resolutionsList);
+```
 
-// generates
+## Examples for `min-`, `max-` and _exact_ resolution examples
+
+```scss
+@use 'double-dash.scss' as mq;
+
+@include mq.resolution-from(hidpi, 1.3);
+@include mq.resolution-to(ldpi, 1.3);
+@include mq.resolution-is(dppx-switch, 2.46875);
+```
+
+generates:
+```css
 @custom-media --hidpi (min-resolution: 1.3dppx), (min-resolution: 124.8dpi);
 @custom-media --ldpi (max-resolution: 1.299dppx), (max-resolution: 124.799dpi);
 @custom-media --dppx-switch (resolution: 2.46875dppx), (resolution: 237dpi);
 ```
 
-💡 Autoprefixer [doesn’t handle](https://github.com/postcss/autoprefixer/issues/775) the conversion of `dppx` factors to `dpi`. You can see in the previous example that Double Dash does it for you. To totally get rid of IE support, wait for [issue #1](https://github.com/meduzen/--media.scss/issues/1) to be handled.
+💡 Autoprefixer [doesn’t handle](https://github.com/postcss/autoprefixer/issues/775) the conversion of `dppx` factors to `dpi`. You can see in the previous example that Double Dash does it for you. To totally get rid of IE support, wait for [issue #1](https://github.com/meduzen/media.scss/issues/1) to be handled.
 
 ## The all-in-one mixin
 
 ```scss
+@use 'double-dash.scss' as mq;
+
 $dppx: (
   '1x': 1, // 1dppx = 96 dpi
   '2x': 2, // 2dppx = 192 dpi
   'switch': 2.46875, // 2.46875dppx = 237ppi
 );
 
-@include --resolution($dppx);
+@include mq.resolution($dppx);
 ```
 
 Available custom media queries:
-- `--resolution-1x`, `--resolution-from-1x`, `--resolution-to-1x`,
-- `--resolution-2x`, `--resolution-from-2x`, `--resolution-to-2x`,
-- `--resolution-switch`, `--resolution-from-switch`, `--resolution-to-switch`.
+- `resolution-1x`, `resolution-from-1x`, `resolution-to-1x`,
+- `resolution-2x`, `resolution-from-2x`, `resolution-to-2x`,
+- `resolution-switch`, `resolution-from-switch`, `resolution-to-switch`.
 
 ### Changing the prefixes
 
-When using the all-round `--resolution` mixin, prefixes (`resolution-from-`, `resolution-` and `resolution-to-`) can be replaced with 3 more arguments:
+When using the all-round `resolution` mixin, prefixes (`resolution-from-`, `resolution-` and `resolution-to-`) can be replaced with 3 more arguments:
 
 ```scss
-@include --resolution($dppx, 'res-from-', 'res-is-', 'res-to-');
+@include mq.resolution($dppx, 'res-from-', 'res-is-', 'res-to-');
 ```
 
 By doing so, the resulting custom media queries become:
 - `--res-1x`, `--res-from-1x`, `--res-to-1x`,
 - `--res-2x`, `--res-from-2x`, `--res-to-2x`,
 - `--res-switch`, `--res-from-switch`, `--res-to-switch`.
+
+This was for the all-round mixin. For the other ones, the third parameter is the prefix:
+
+```scss
+@include mq.resolution-from('nexus-7', 1.3, 'more-dense-than-');
+```
+
+generates:
+```css
+@custom-media --more-dense-than-nexus-7 (min-resolution: 1.3dppx), (min-resolution: 124.8dpi);
+```

--- a/docs/ranged-sizes-mixins.md
+++ b/docs/ranged-sizes-mixins.md
@@ -2,32 +2,48 @@
 
 *(Height: soon)*
 
-## Mixins syntaxes
+## Mixins import
+
+Use one of these two to import the mixins in your file:
 
 ```scss
-@include --w-from(name, width);
-@include --w-to(name, width);
-@include --w-is(name, width);
-@include --w-from-to(name, smallerWidth, otherName, greaterWidth);
-@include --w(widthsList);
+// import all double-dash.scss
+@use 'double-dash.scss' as mq;
+
+// only import sizes mixins
+@use 'double-dash.scss/src/mixins/sizes' as mq;
 ```
 
-## `min-`, `max-` and exact width examples
+## Syntax
 
 ```scss
-@include --w-from(smallest, 20em);
-@include --w-is(wii-u, 980px);
-@include --w-to(filters-collapsed, 50em);
-@include --w-from-to(smallest, 20em, filters-collapsed, 50em);
+@include mq.w-from(name, width);
+@include mq.w-to(name, width);
+@include mq.w-is(name, width);
+@include mq.w-from-to(name, smallerWidth, otherName, greaterWidth);
+@include mq.w(widthsList);
+```
 
-// generates
+## Examples for `min-`, `max-` and _exact_ width examples
+
+```scss
+@use 'double-dash.scss' as mq;
+
+@include mq.w-from(smallest, 20em);
+@include mq.w-is(wii-u, 980px);
+@include mq.w-to(filters-collapsed, 50em);
+@include mq.w-from-to(smallest, 20em, filters-collapsed, 50em);
+```
+
+generates:
+```css
 @custom-media --smallest (min-width: 20em);
 @custom-media --wii-u (width: 980px);
 @custom-media --filters-collapsed (max-width: 49.999em);
 @custom-media --smallest-to-filters-collapsed (min-width: 20em) and (max-width: 49.999em);
 ```
 
-## All-in-one mixin example
+## The all-in-one mixin
 
 Let’s imagine a responsive calendar having three display modes depending on the viewport width:
 - compressed;
@@ -35,13 +51,15 @@ Let’s imagine a responsive calendar having three display modes depending on th
 - two weeks visible.
 
 ```scss
+@use 'double-dash.scss' as mq;
+
 $breakpoints-cal: (
   'cal-compressed': 20em,
   'cal-week': 45em,
   'cal-2-weeks': 94em,
 );
 
-@include --w($breakpoints-cal);
+@include mq.w($breakpoints-cal);
 ```
 
 Available custom media queries:
@@ -58,16 +76,18 @@ Available custom media queries:
 --cal-week-to-cal-2-weeks // (min-width: 45em) and (max-width: 93.999em)
 ```
 
-💡Because width based media queries are the most common ones, they deserve to be the shortest to be written, so the names generated with `--w()` are shorter than other outputs using Double Dash ranged mixins:
-- Instead of `--w-from-cal-week`, it’s `--cal-week`.
-- Instead of `--w-to-cal-week`, it’s `--to-cal-week`.
+💡 Because width based media queries are the most common ones, they deserve to be the fastest to be written, so the names generated with `w()` are shorter than other outputs using Double Dash ranged mixins:
+- Instead of `w-from-cal-week`, it’s `--cal-week`.
+- Instead of `w-to-cal-week`, it’s `--to-cal-week`.
+
+If you want more expressive names for width media queries, you can [change their prefix](#changing-the-prefixes).
 
 ### Changing the prefixes
 
-When using the all-round `--w` mixin, prefixes (`` and `to-`) can be replaced with 2 more arguments:
+When using the all-round `w` mixin, prefixes (`` and `to-`) can be replaced with 2 more arguments:
 
 ```scss
-@include --w($breakpoints-cal, 'w-from-', 'w-to-');
+@include mq.w($breakpoints-cal, 'w-from-', 'w-to-');
 ```
 The resulting available custom media queries become:
 - `--w-from-cal-compressed`
@@ -79,3 +99,14 @@ The resulting available custom media queries become:
 - `--cal-compressed-to-cal-week`
 - `--cal-compressed-to-cal-2-weeks`
 - `--cal-week-to-cal-2-weeks`
+
+This was for the all-round mixin. For the other ones, the third parameter is the prefix:
+
+```scss
+@include mq.w-from(small-phone, 20em, 'wider-than-');
+```
+
+generates:
+```css
+@custom-media --wider-than-small-phone (min-width: 20em);
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "double-dash.scss",
-  "version": "0.8.0",
+  "version": "1.0.0-rc.0",
   "description": "A set of SCSS mixins and variables to organize custom media queries.",
   "main": "src/double-dash.scss",
   "scripts": {

--- a/src/double-dash.scss
+++ b/src/double-dash.scss
@@ -1,3 +1,10 @@
-@import 'mixins/mixins';
-@import 'variables/variables';
+// Setup debug mode
+$debug: false !default;
+@forward 'mixins/base' with ($debug: $debug);
+
+// Forward mixins and setup all the @custom-media.
+@forward 'mixins';
+@forward 'variables';
+
+// Potential idea for the future…
 // @import 'collections/collections';

--- a/src/mixins/_base.scss
+++ b/src/mixins/_base.scss
@@ -1,4 +1,4 @@
-@import 'debug';
+$debug: false !default;
 
 /*
  * MEDIA MIXIN
@@ -10,12 +10,12 @@
  *  $argsFeatures: media features
  *
  * Example:
- * @include --media(wide-as-hell, 'width >= 150em')
+ * @include media(wide-as-hell, 'width >= 150em')
  * generates
  * @custom-media --wide-as-hell (min-width: 150em)
  */
 
-@mixin --media($name, $argsFeatures...) {
+@mixin media($name, $argsFeatures...) {
   $features: null;
 
   $index: 1;
@@ -35,13 +35,13 @@
 
   @custom-media --#{$name} #{$features};
 
-  @if $dash-dash-should-debug {
+  @if $debug {
     @debug unquote('@custom-media ') --#{$name} unquote('#{$features}');
   }
 }
 
-/* --media() ALIAS */
+/* media() ALIAS */
 
-@mixin --m($name, $args...) {
-  @include --media($name, $args);
+@mixin m($name, $args...) {
+  @include media($name, $args);
 }

--- a/src/mixins/_base.scss
+++ b/src/mixins/_base.scss
@@ -20,8 +20,13 @@
 
   $index: 1;
   @each $feature in $argsFeatures {
+
+    /**
+     * Add separator (coma) between media features.
+     * https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_features
+     */
     @if $index > 1 {
-      $features: #{$features ','};
+      $features: $features + ',';
     }
     $features: #{$features unquote('(#{$feature})')};
 

--- a/src/mixins/_debug.scss
+++ b/src/mixins/_debug.scss
@@ -1,5 +1,0 @@
-$dash-dash-should-debug: false;
-
-@if variable-exists('dash-dash-debug') == true and $dash-dash-debug == true {
-  $dash-dash-should-debug: true;
-}

--- a/src/mixins/_ratio.scss
+++ b/src/mixins/_ratio.scss
@@ -1,3 +1,5 @@
+@use './base' as *;
+
 /* VIEWPORT RATIO IN FRACTION
  *
  * Turns a SASS list into resolution custom media queries.
@@ -11,7 +13,7 @@
  * Example usage:
  *
  * $ratios: ('16-9': 16/9, '4-3': 4/3);
- * @include --ratio($ratios);
+ * @include ratio($ratios);
  *
  * Available custom media queries:
  *
@@ -24,22 +26,22 @@
  *   2. `orientation` is limited to two values (`portrait` and `landscape`).
  */
 
-@mixin --ratio($ratios, $from-prefix: 'ratio-from-', $exact-prefix: 'ratio-', $to-prefix: 'ratio-to-') {
+@mixin ratio($ratios, $from-prefix: 'ratio-from-', $exact-prefix: 'ratio-', $to-prefix: 'ratio-to-') {
   @each $name, $ratio in $ratios {
-    @include --ratio-from($name, $ratio, $from-prefix);
-    @include --ratio-is($name, $ratio, $exact-prefix);
-    @include --ratio-to($name, $ratio, $to-prefix);
+    @include ratio-from($name, $ratio, $from-prefix);
+    @include ratio-is($name, $ratio, $exact-prefix);
+    @include ratio-to($name, $ratio, $to-prefix);
   }
 }
 
-@mixin --ratio-from($name, $ratio, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'aspect-ratio >=' #{$ratio});
+@mixin ratio-from($name, $ratio, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'aspect-ratio >=' #{$ratio});
 }
 
-@mixin --ratio-is($name, $ratio, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, unquote('aspect-ratio:') #{$ratio});
+@mixin ratio-is($name, $ratio, $prefix: null) {
+  @include media(#{$prefix}#{$name}, unquote('aspect-ratio:') #{$ratio});
 }
 
-@mixin --ratio-to($name, $ratio, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'aspect-ratio <=' #{$ratio});
+@mixin ratio-to($name, $ratio, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'aspect-ratio <=' #{$ratio});
 }

--- a/src/mixins/_resolution.scss
+++ b/src/mixins/_resolution.scss
@@ -1,3 +1,5 @@
+@use './base' as *;
+
 /* RESOLUTION (PIXEL DENSITY) IN DPPX
  *
  * Turns a SASS list into resolution custom media queries.
@@ -11,7 +13,7 @@
  * Example usage:
  *
  * $dppx: ('1x': 1, '2x': 2, 'switch': 2.46875);
- * @include --resolution($dppx);
+ * @include resolution($dppx);
  *
  * Available custom media queries:
  *
@@ -23,22 +25,22 @@
  * https://developer.mozilla.org/en-US/docs/Web/CSS/resolution
  */
 
-@mixin --resolution($densities, $from-prefix: 'resolution-from-', $exact-prefix: 'resolution-', $to-prefix: 'resolution-to-') {
+@mixin resolution($densities, $from-prefix: 'resolution-from-', $exact-prefix: 'resolution-', $to-prefix: 'resolution-to-') {
   @each $name, $density in $densities {
-    @include --resolution-from($name, $density, $from-prefix);
-    @include --resolution-is($name, $density, $exact-prefix);
-    @include --resolution-to($name, $density, $to-prefix);
+    @include resolution-from($name, $density, $from-prefix);
+    @include resolution-is($name, $density, $exact-prefix);
+    @include resolution-to($name, $density, $to-prefix);
   }
 }
 
-@mixin --resolution-from($name, $density, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'resolution >=' #{$density}dppx, 'resolution >=' #{$density * 96}dpi);
+@mixin resolution-from($name, $density, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'resolution >=' #{$density}dppx, 'resolution >=' #{$density * 96}dpi);
 }
 
-@mixin --resolution-is($name, $density, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, unquote('resolution:') #{$density}dppx, unquote('resolution:') #{$density * 96}dpi);
+@mixin resolution-is($name, $density, $prefix: null) {
+  @include media(#{$prefix}#{$name}, unquote('resolution:') #{$density}dppx, unquote('resolution:') #{$density * 96}dpi);
 }
 
-@mixin --resolution-to($name, $density, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'resolution <' #{$density}dppx, 'resolution <' #{$density * 96}dpi);
+@mixin resolution-to($name, $density, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'resolution <' #{$density}dppx, 'resolution <' #{$density * 96}dpi);
 }

--- a/src/mixins/_sizes.scss
+++ b/src/mixins/_sizes.scss
@@ -1,3 +1,5 @@
+@use './base' as *;
+
 /* SIZES (WIDTH AND HEIGHT)
  *
  * Turns a SASS list into width or height custom media queries.
@@ -10,7 +12,7 @@
  * Example usage:
  *
  * $breakpoints-widths: ('smallest': 20em, 'switch': 80em);
- * @include --w($breakpoints-widths);
+ * @include w($breakpoints-widths);
  *
  * Available custom media queries:
  *
@@ -21,62 +23,62 @@
 
 // Width
 
-@mixin --w($widths, $from-prefix: null, $to-prefix: 'to-') {
+@mixin w($widths, $from-prefix: null, $to-prefix: 'to-') {
   @each $name, $width in $widths {
-    @include --w-from(#{$name}, #{$width}, #{$from-prefix});
-    @include --w-to(#{$name}, #{$width}, #{$to-prefix});
+    @include w-from(#{$name}, #{$width}, #{$from-prefix});
+    @include w-to(#{$name}, #{$width}, #{$to-prefix});
 
     @each $other-name, $other-width in $widths {
       @if $width < $other-width {
-        @include --w-from-to(#{$name}, #{$width}, #{$other-name}, #{$other-width});
+        @include w-from-to(#{$name}, #{$width}, #{$other-name}, #{$other-width});
       }
     }
   }
 }
 
-@mixin --w-from($name, $width, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'width >=' #{$width});
+@mixin w-from($name, $width, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'width >=' #{$width});
 }
 
-@mixin --w-is($name, $width, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, unquote('width:') #{$width});
+@mixin w-is($name, $width, $prefix: null) {
+  @include media(#{$prefix}#{$name}, unquote('width:') #{$width});
 }
 
-@mixin --w-to($name, $width, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'width <' #{$width});
+@mixin w-to($name, $width, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'width <' #{$width});
 }
 
-@mixin --w-from-to($min-name, $min-width, $max-name, $max-width) {
-  @include --media(#{$min-name}-to-#{$max-name}, #{$min-width} '<= width <' #{$max-width});
+@mixin w-from-to($min-name, $min-width, $max-name, $max-width) {
+  @include media(#{$min-name}-to-#{$max-name}, #{$min-width} '<= width <' #{$max-width});
 }
 
 // Height
 
-@mixin --h($heights, $from-prefix: 'h-', $to-prefix: 'h-to-') {
+@mixin h($heights, $from-prefix: 'h-', $to-prefix: 'h-to-') {
   @each $name, $height in $heights {
-    @include --h-from(#{$name}, #{$height}, #{$from-prefix});
-    @include --h-to(#{$name}, #{$height}, #{$to-prefix});
+    @include h-from(#{$name}, #{$height}, #{$from-prefix});
+    @include h-to(#{$name}, #{$height}, #{$to-prefix});
 
     @each $other-name, $other-height in $heights {
       @if $height < $other-height {
-        @include --h-from-to(#{$name}, #{$height}, #{$other-name}, #{$other-height});
+        @include h-from-to(#{$name}, #{$height}, #{$other-name}, #{$other-height});
       }
     }
   }
 }
 
-@mixin --h-from($name, $height, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'height >=' #{$height});
+@mixin h-from($name, $height, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'height >=' #{$height});
 }
 
-@mixin --h-is($name, $height, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, unquote('height:') #{$height});
+@mixin h-is($name, $height, $prefix: null) {
+  @include media(#{$prefix}#{$name}, unquote('height:') #{$height});
 }
 
-@mixin --h-to($name, $height, $prefix: null) {
-  @include --media(#{$prefix}#{$name}, 'height <' #{$height});
+@mixin h-to($name, $height, $prefix: null) {
+  @include media(#{$prefix}#{$name}, 'height <' #{$height});
 }
 
-@mixin --h-from-to($min-name, $min-height, $max-name, $max-height) {
-  @include --media(h-#{$min-name}-to-#{$max-name}, #{$min-height} '<= height <' #{$max-height});
+@mixin h-from-to($min-name, $min-height, $max-name, $max-height) {
+  @include media(h-#{$min-name}-to-#{$max-name}, #{$min-height} '<= height <' #{$max-height});
 }

--- a/src/mixins/index.scss
+++ b/src/mixins/index.scss
@@ -1,14 +1,14 @@
 // Base mixin used by the others
-@import 'base';
+@forward 'base';
 
 // Types mixins
-@import 'types/types';
+@forward 'types/types';
 
 // Mixins for viewport aspect-ratio
-@import 'ratio';
+@forward 'ratio';
 
 // Mixins for device resolution
-@import 'resolution';
+@forward 'resolution';
 
 // Mixins for viewport width and height
-@import 'sizes';
+@forward 'sizes';

--- a/src/mixins/types/_print.scss
+++ b/src/mixins/types/_print.scss
@@ -1,15 +1,15 @@
 /*
  * MEDIA PRINT MIXIN
  *
- * A print based mixin. Same signature as the `--media` one.
+ * A print based mixin. Same signature as the `media` one.
  *
  * Example:
- * @include --print(small-sheet, 'width < 20cm')
+ * @include print(small-sheet, 'width < 20cm')
  * generates
  * @custom-media --small-sheet print and (max-width: 19.999cm)
  */
 
-@mixin --print($name, $argsFeatures...) {
+@mixin print($name, $argsFeatures...) {
   $features: null;
 
   $index: 1;

--- a/src/mixins/types/_screen.scss
+++ b/src/mixins/types/_screen.scss
@@ -1,15 +1,15 @@
 /*
  * MEDIA SCREEN MIXIN
  *
- * A screen based mixin. Same signature as the `--media` one.
+ * A screen based mixin. Same signature as the `media` one.
  *
  * Example:
- * @include --screen(wide-as-hell, 'width >= 150em')
+ * @include screen(wide-as-hell, 'width >= 150em')
  * generates
  * @custom-media --wide-as-hell screen and (min-width: 150em)
  */
 
-@mixin --screen($name, $argsFeatures...) {
+@mixin screen($name, $argsFeatures...) {
   $features: null;
 
   $index: 1;

--- a/src/mixins/types/_speech.scss
+++ b/src/mixins/types/_speech.scss
@@ -1,11 +1,10 @@
 /*
  * MEDIA SPEECH MIXIN
  *
- * A speech based mixin. Same signature as the `--media` one.
- *
+ * A speech based mixin. Same signature as the `media` one.
  */
 
-@mixin --speech($name, $argsFeatures...) {
+@mixin speech($name, $argsFeatures...) {
   $features: null;
 
   $index: 1;

--- a/src/variables/_motion.scss
+++ b/src/variables/_motion.scss
@@ -1,15 +1,17 @@
+@use '../mixins' as *;
+
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
 
 $reduced-motion: 'prefers-reduced-motion: reduce';
-@include --m(reduced-motion, $reduced-motion);
-@include --m(less-motion, $reduced-motion);
-@include --m(no-motion, $reduced-motion);
-@include --m(stop, $reduced-motion);
+@include m(reduced-motion, $reduced-motion);
+@include m(less-motion, $reduced-motion);
+@include m(no-motion, $reduced-motion);
+@include m(stop, $reduced-motion);
 
 $no-motion-preference: 'prefers-reduced-motion: no-preference';
-@include --m(no-motion-preference, $no-motion-preference);
-@include --m(motion, $no-motion-preference);
-@include --m(full-motion, $no-motion-preference);
-@include --m(play, $no-motion-preference);
-@include --m(animate-all-the-things, $no-motion-preference);
-@include --m(party-parrot, $no-motion-preference);
+@include m(no-motion-preference, $no-motion-preference);
+@include m(motion, $no-motion-preference);
+@include m(full-motion, $no-motion-preference);
+@include m(play, $no-motion-preference);
+@include m(animate-all-the-things, $no-motion-preference);
+@include m(party-parrot, $no-motion-preference);

--- a/src/variables/_ratio.scss
+++ b/src/variables/_ratio.scss
@@ -1,3 +1,5 @@
+@use '../mixins' as *;
+
 /* VIEWPORT ASPECT RATIO
  *
  * Available custom media queries:
@@ -10,12 +12,12 @@ $ratio: (
   '16-9': '16/9', // 1.7777, TV
 );
 
-@include --ratio($ratio, 'from-', 'is-', 'to-');
+@include ratio($ratio, 'from-', 'is-', 'to-');
 
-@include --ratio-is('square', '1/1');
+@include ratio-is('square', '1/1');
 
-@include --ratio-from('landscape', '10001/10000');
-@include --ratio-from('horizontal', '10001/10000');
+@include ratio-from('landscape', '10001/10000');
+@include ratio-from('horizontal', '10001/10000');
 
-@include --ratio-to('portrait', '9999/10000');
-@include --ratio-to('vertical', '9999/10000');
+@include ratio-to('portrait', '9999/10000');
+@include ratio-to('vertical', '9999/10000');

--- a/src/variables/_resolution.scss
+++ b/src/variables/_resolution.scss
@@ -1,18 +1,21 @@
+@use '../mixins' as *;
+
 $dppx: (
   '1x': 1, // 96 dpi
   '2x': 2, // 192 dpi
-  'switch': 2.46875, // 237dpi, 1280px * 720px, 6.2 inches
+  'switch': 2.46739583, // 236.87dpi, 1280px * 720px, 6.2 inches
   'switch-lite': 2.78145833, // 267.02dpi, 1280px * 720px, 5.5 inches
+  'switch-oled': 2.18541667, // 209.8dpi, 1280px * 720px, 7 inches
 );
 
 // --resolution-from-1x, --resolution-from-2x,--resolution-from-switch
 // --resolution-1x, --resolution-2x, --resolution-switch
 // --resolution-to-1x, --resolution-to-2x, --resolution-to-switch
-@include --resolution($dppx);
+@include resolution($dppx);
 
-// --hidpi
-@include --resolution-from(hidpi, 1.3);
-@include --resolution-from(hdpi, 1.3);
+// hidpi
+@include resolution-from(hidpi, 1.3);
+@include resolution-from(hdpi, 1.3);
 
 // --ldpi
-@include --resolution-to(ldpi, 1.3);
+@include resolution-to(ldpi, 1.3);

--- a/src/variables/_ui.scss
+++ b/src/variables/_ui.scss
@@ -1,3 +1,5 @@
+@use '../mixins' as *;
+
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode
 @custom-media --minimal-ui (display-mode: minimal-ui);
 @custom-media --fullscreen (display-mode: fullscreen);
@@ -11,21 +13,21 @@
 
 // prefers-color-scheme: light
 $colors-scheme-default: 'prefers-color-scheme: light';
-@include --m(light, $colors-scheme-default);
-@include --m(any-theme, $colors-scheme-default);
-@include --m(any-color-scheme, $colors-scheme-default);
-@include --m(no-theme-preference, $colors-scheme-default);
-@include --m(no-color-scheme-preference, $colors-scheme-default);
+@include m(light, $colors-scheme-default);
+@include m(any-theme, $colors-scheme-default);
+@include m(any-color-scheme, $colors-scheme-default);
+@include m(no-theme-preference, $colors-scheme-default);
+@include m(no-color-scheme-preference, $colors-scheme-default);
 
 // https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-transparency
 
 // prefers-reduced-transparency: reduce
 $reduced-transparency: 'prefers-reduced-transparency: reduce';
-@include --m(reduced-transparency, $reduced-transparency);
-@include --m(less-transparency, $reduced-transparency);
+@include m(reduced-transparency, $reduced-transparency);
+@include m(less-transparency, $reduced-transparency);
 
 // prefers-reduced-transparency: no-preference
 $no-transparency-preference: 'prefers-reduced-transparency: no-preference';
-@include --m(no-transparency-preference, $no-transparency-preference);
-@include --m(transparency, $no-transparency-preference);
-@include --m(full-transparency, $no-transparency-preference);
+@include m(no-transparency-preference, $no-transparency-preference);
+@include m(transparency, $no-transparency-preference);
+@include m(full-transparency, $no-transparency-preference);

--- a/src/variables/index.scss
+++ b/src/variables/index.scss
@@ -2,13 +2,13 @@
 // https://drafts.csswg.org/mediaqueries-4/
 // https://drafts.csswg.org/mediaqueries-5/
 
-@import 'color';
-@import 'connection';
-@import 'js';
-@import 'light';
-@import 'motion';
-@import 'pointer';
-@import 'ratio';
-@import 'refresh';
-@import 'resolution';
-@import 'ui';
+@forward 'color';
+@forward 'connection';
+@forward 'js';
+@forward 'light';
+@forward 'motion';
+@forward 'pointer';
+@forward 'ratio';
+@forward 'refresh';
+@forward 'resolution';
+@forward 'ui';


### PR DESCRIPTION
Closes #14.

This PR has been extensively tested in a local project running on Dart SASS.

My plan is to merge it and ship a `1.0.0-beta`, and then using it in all my projects using Vite (as Vite only allows Dart SASS) before bumping it to `1.0.0`.

This PR also:
- [fixes Nintendo Switch `ddpx`](https://github.com/meduzen/--media.scss/blob/2db0feaf890fc2188069ffc4c87ea81be00af601/src/variables/_resolution.scss#L6);
- adds a custom media query [for the Switch OLED](https://github.com/meduzen/--media.scss/blob/2db0feaf890fc2188069ffc4c87ea81be00af601/src/variables/_resolution.scss#L8) because why not;
- removes an unwanted space between media features 8842e23;
- updates various parts of the documentation a15c5d8 d451d85 2db0fea.