### PR TITLE
Use integer in aspect-ratio

### DIFF
--- a/src/variables/_ratio.scss
+++ b/src/variables/_ratio.scss
@@ -14,7 +14,7 @@ $ratio: (
 
 @include ratio($ratio, 'from-', 'is-', 'to-');
 
-@include ratio-is('square', '1/1');
+@include ratio-is('square', '1');
 
 @include ratio-from('landscape', '10001/10000');
 @include ratio-from('horizontal', '10001/10000');


### PR DESCRIPTION
This is a minor enhancement.

PostCSS will adapt to a fractional [ratio](https://w3c.github.io/csswg-drafts/css-values-4/#ratio-value) for browser not supporting the use of a single number. At this time of writing, no browser supports it.